### PR TITLE
Correct the function of "cor.dist"

### DIFF
--- a/Figure 4.R
+++ b/Figure 4.R
@@ -7,7 +7,7 @@ library(geneplotter)
 
 cor.dist <- function (x) 
 {
-  as.dist(1 - cor(t(x), use="pairwise.complete.obs"), method="kendall")
+  as.dist(1 - cor(t(x), use="pairwise.complete.obs", method="kendall"))
 }
 dist.manhattan <- function(x){dist(x, method="manhattan")}
 hclust.ward.d <- function(x){hclust(x, method="ward.D")}


### PR DESCRIPTION
The "kendall" method doesn't belong to the argument of _as.dist_ and it is the method of "_cor_". I believe the author give the wrong position of ")".